### PR TITLE
some fixes from monday

### DIFF
--- a/include/acc/acc.h
+++ b/include/acc/acc.h
@@ -8,7 +8,7 @@ class acc : public mosqpp::mosquittopp
 	/* mosquitto */
 	char host[16];
 	const char* id = "acc";
-	const char* topic = "savm/car/0/#";
+	const char* topic = "savm/car/0/+";
 	int port;
 	int keepalive;
 	enum {
@@ -23,6 +23,7 @@ class acc : public mosqpp::mosquittopp
 	float g_maxBrake = 1.0;
 	int allValues;
 	sem_t allValSem;
+	sem_t allData;
 	struct SensorDataIn sdi;
 
 public:

--- a/include/savm/savm.h
+++ b/include/savm/savm.h
@@ -19,6 +19,7 @@ class savm : public mosqpp::mosquittopp
 	protobuf::CommandDataIn cdi;
 	int allValues;
 	sem_t allValSem;
+	sem_t allData;
 
 	void on_connect(int rc);
 	void on_disconnect(int rc);

--- a/include/servo_client/servo_client.h
+++ b/include/servo_client/servo_client.h
@@ -7,7 +7,7 @@ private:
 	/* mosquitto */
 	char host[16];
 	const char* id = "servo_client";
-	const char* topic = "rcar/control/motor/#";
+	const char* topic = "rcar/control/servo/#";
 	int port;
 	int keepalive;
 

--- a/run/cc-sadapt.run
+++ b/run/cc-sadapt.run
@@ -48,7 +48,7 @@ set config {
 		<any-service> <parent/> <any-child/> </any-service>
 	</default-route>
 
-	<start name="net_servo_adapter">
+	<start name="servo_adapter">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<network dhcp="yes" ip-address="192.168.100.42" subnet-mask="255.255.255.0" default-gateway="192.168.100.254" />

--- a/src/app/servo_adapter/servo_adapter.cc
+++ b/src/app/servo_adapter/servo_adapter.cc
@@ -115,9 +115,11 @@ void servo_adapter::on_message(const struct mosquitto_message *message)
 		Genode::log("unknown topic: ", (const char *)message->topic);
 	}
 
-	if (!(rbrake %= 2)) {
+	/* check if we got both values for the brake */
+	if (rbrake == 2) {
 		snprintf(buffer, sizeof(buffer), "%d", transform_brake((brakeRL + brakeRR) / 2));
 		publish(NULL, "rcar/control/servo/brake/r", strlen(buffer), buffer);
+		rbrake = 0;
 	}
 }
 


### PR DESCRIPTION
- Fixed wrong topic in servo_client.h
- Fixed wrong application in cc-sadapt.run
- Fixed rear brake in servo_adapter.cc

-> The semaphores shouldn't make any real difference - the same applies for the topic change in acc.h

Please make sure, that when you run the test case, that every mosquitto client gets **its own** ip address - otherwise message flow is broken and the whole scenario won't work.

**Tip:** You can watch all packets exchanged by mosquitto by running the following in a terminal:
`mosquitto_sub -t "#" -v`

------

I additionally found out, that the performance is relatively bad (simulation speed at lowest setting otherwise the simulation hangs up pretty badly). I'm not sure where this comes from, since data exchange between the simulation and the sa/vm is done with TCP_NODELAY enabled and mosquitto publishes with the same setting. Maybe it's the serialization of the messages by protobuf? Maybe its the calculation of the acc? This needs some time for measurement and debugging.

In comparison to the old showcase (parking) from the practical course, the sa/vm now only sends back control commands **after** the acc calculated the control commands for the next simulation step and transmitted them. Meaning the simulation has to wait for the full cycle
`simulation -> sa/vm -> acc -> sa/vm -> simulation` before executing the next simulation step.
In the old show case the sa/vm directly send back control commands which may have been from one of the previous simulation steps, since a second thread listens for control commands and both threads just share buffer variables.
The current method has the advantage to be deterministic since we control every single simulation step and should get better/exact and reproducible results.